### PR TITLE
There is no way to force a breadcrumb to be current (when it's not)

### DIFF
--- a/lib/loaf/controller_extensions.rb
+++ b/lib/loaf/controller_extensions.rb
@@ -56,7 +56,7 @@ module Loaf
       end
 
       def breadcrumb(name, url, options={})
-        _breadcrumbs << Loaf::Crumb.new(name, url)
+        _breadcrumbs << Loaf::Crumb.new(name, url, options[:force])
       end
       alias :add_breadcrumb :breadcrumb
 

--- a/lib/loaf/crumb.rb
+++ b/lib/loaf/crumb.rb
@@ -2,5 +2,5 @@
 
 module Loaf
   # Basic crumb container
-  Crumb = Struct.new(:name, :url, :styles)
+  Crumb = Struct.new(:name, :url, :force)
 end # Loaf

--- a/lib/loaf/view_extensions.rb
+++ b/lib/loaf/view_extensions.rb
@@ -10,8 +10,8 @@ module Loaf
 
     # Adds breadcrumbs inside view.
     #
-    def breadcrumb(name, url)
-      _breadcrumbs.push Loaf::Crumb.new(name, url)
+    def breadcrumb(name, url, options={})
+      _breadcrumbs.push Loaf::Crumb.new(name, url, options[:force])
     end
     alias :add_breadcrumb :breadcrumb
 
@@ -26,7 +26,7 @@ module Loaf
 
         url = url_for _process_url_for(crumb.url)
 
-        styles = current_page?(url) ? "#{options[:style_classes]}" : ''
+        styles = (current_page?(url) || crumb.force) ? "#{options[:style_classes]}" : ''
 
         block.call(name, url, styles)
       end

--- a/spec/integration/crumbs_routing_spec.rb
+++ b/spec/integration/crumbs_routing_spec.rb
@@ -40,4 +40,17 @@ describe "crumbs routing" do
       end
     end
   end
+
+  context 'forcing breadcrumb' do
+    it 'should be current when forced' do
+      visit new_post_path
+      click_button "Create"
+
+      page.current_path.should == posts_path
+      within '#breadcrumbs' do
+        page.should have_content 'New Post'
+        page.should have_selector('.selected')
+      end
+    end
+  end
 end

--- a/spec/loaf/controller_extensions_spec.rb
+++ b/spec/loaf/controller_extensions_spec.rb
@@ -42,7 +42,7 @@ describe Loaf::ControllerExtensions do
     let(:instance) { Controller.new }
 
     it 'instantiates breadcrumbs container' do
-      Loaf::Crumb.should_receive(:new).with(name, url)
+      Loaf::Crumb.should_receive(:new).with(name, url, nil)
       instance.add_breadcrumb(name,url)
     end
 

--- a/spec/loaf/view_extensions_spec.rb
+++ b/spec/loaf/view_extensions_spec.rb
@@ -26,7 +26,7 @@ describe Loaf::ViewExtensions do
     end
 
     it 'creates crumb instance' do
-      Loaf::Crumb.should_receive(:new).with(name, url)
+      Loaf::Crumb.should_receive(:new).with(name, url, nil)
       instance.breadcrumb name, url
     end
 

--- a/spec/rails_app/app/controllers/posts_controller.rb
+++ b/spec/rails_app/app/controllers/posts_controller.rb
@@ -6,7 +6,12 @@ class PostsController < ApplicationController
   end
 
   def new
-    add_breadcrumb 'New Post', 'new_post_path' 
+    add_breadcrumb 'New Post', 'new_post_path'
+  end
+
+  def create
+    add_breadcrumb 'New Post', 'new_post_path', :force => true
+    render :action => :new
   end
 
 end

--- a/spec/rails_app/app/views/posts/new.html.erb
+++ b/spec/rails_app/app/views/posts/new.html.erb
@@ -1,1 +1,4 @@
 <h1>Posts:new</h1>
+<%= form_tag posts_path, :method => "POST" do %>
+  <% submit_tag "Create"%>
+<% end %>


### PR DESCRIPTION
This is really useful when on a create action, because you likely want the breadcrumb to be for "New" even though the action rendered was create. This is especially true with rails resource routing where the create path is only valid on POST, a get on the create path will take you to the index path.

so, i added a force option
```ruby
add breadcrumb "New", 'new_path', :force => true
```